### PR TITLE
Misc updates after trying to run clang-tidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv/
 dist/
 *.egg-info/
 *.ini
+*.xml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 venv/
 dist/
 *.egg-info/
+*.ini

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ After a process of generating a compile_commands.json, you can run processcdb wi
 
     processcdb --tool clang-tidy
 
-This will try to locate the json file from current working directory and runs the tool, in this case
-clang-tidy, against all files that are compiled and not blacklisted in processcdb comfig file or in
+This will try to locate the json file from current working directory and runs the tool, in this case the 
+clang-tidy tool as defined in the config file, against all files that are compiled and not blacklisted in processcdb config file or in
 tools own configuration file and generates the output to standard output. If you need to run the tool when you
 don't have access to change the current working directory, you can pass `--cdb` and absolute location:
 
@@ -77,7 +77,7 @@ capture the standard output or provide `--config` parameter.
 ## Configuration file
 
 Each tool has a separate section and each section can be configured either in the tool specific section or
-in default. Minimal. single tool configuratio would look something like this:
+in default. The minimal single tool configuration would look something like this:
 
     [clang-tidy]
     binary=C:\llvm-11.0.0\bin\clang-tidy.exe

--- a/run_processcdb.bat
+++ b/run_processcdb.bat
@@ -1,0 +1,6 @@
+@echo off
+pushd
+
+D:\fone\branch\external\ego\dev\python3\bin\python.exe src/processcdb --tool clang-tidy --xml --output results.xml --cdb D:\fone\branch\external\ego\dev\clang_tools\compile_commands.json
+
+popd

--- a/src/processcdb/__init__.py
+++ b/src/processcdb/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from ._version import get_versions
+from _version import get_versions
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/src/processcdb/__main__.py
+++ b/src/processcdb/__main__.py
@@ -38,7 +38,7 @@ def main():
     if args.cdb.is_file():
         cdb = json.loads(args.cdb.read_text())
         if cdb:
-            if args.commit_a is not None:
+            #if args.commit_a is not None:
                 #cdb = filterByChangelist(cdb, (args.commit_a, args.commit_b))
 
             if not args.allow_dupes:

--- a/src/processcdb/__main__.py
+++ b/src/processcdb/__main__.py
@@ -4,10 +4,9 @@ import sys
 import json
 import traceback
 from cdb_tools import TOOLS
-from misc import remove_untouched_files, remove_dupes, argument_parser
+from misc import remove_dupes, argument_parser
 from configparser import ConfigParser
 from logger import LOGGER as log, LOG_LEVELS
-
 
 def main():
     args = argument_parser(TOOLS).parse_args()
@@ -40,7 +39,7 @@ def main():
         cdb = json.loads(args.cdb.read_text())
         if cdb:
             if args.commit_a is not None:
-                cdb = remove_untouched_files(cdb, (args.commit_a, args.commit_b))
+                #cdb = filterByChangelist(cdb, (args.commit_a, args.commit_b))
 
             if not args.allow_dupes:
                 cdb = remove_dupes(cdb)

--- a/src/processcdb/__main__.py
+++ b/src/processcdb/__main__.py
@@ -3,10 +3,10 @@
 import sys
 import json
 import traceback
-from .cdb_tools import TOOLS
-from .misc import remove_untouched_files, remove_dupes, argument_parser
+from cdb_tools import TOOLS
+from misc import remove_untouched_files, remove_dupes, argument_parser
 from configparser import ConfigParser
-from .logger import LOGGER as log, LOG_LEVELS
+from logger import LOGGER as log, LOG_LEVELS
 
 
 def main():

--- a/src/processcdb/cdb_tools.py
+++ b/src/processcdb/cdb_tools.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from .toolbase import Tool  # noqa: F401
-from .clangtidy import ClangTidy  # noqa: F401
-from .clang import Clang  # noqa: F401
-from .lizard import Lizard  # noqa: F401
-from .cppcheck import CppCheck  # noqa: F401
+from toolbase import Tool  # noqa: F401
+from clangtidy import ClangTidy  # noqa: F401
+from clang import Clang  # noqa: F401
+from lizard import Lizard  # noqa: F401
+from cppcheck import CppCheck  # noqa: F401
 
 TOOLS = {
     "clang-tidy": ClangTidy,

--- a/src/processcdb/clang.py
+++ b/src/processcdb/clang.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from .misc import is_any_windows
-from .toolbase import Tool
+from misc import is_any_windows
+from toolbase import Tool
 
 
 class Clang(Tool):

--- a/src/processcdb/clang.py
+++ b/src/processcdb/clang.py
@@ -16,8 +16,10 @@ class Clang(Tool):
         if args.output is not None:
             arguments.extend([f"--output {args.output}"])
 
-        if is_any_windows():
-            arguments.extend([f"--use-analyzer {self.binary}"])
+        absoluteBinaryPath = Path(self.binary).resolve()
 
-        final_command = f"{self.binary} {' '.join(arguments)}"
+        if is_any_windows():
+            arguments.extend([f"--use-analyzer {absoluteBinaryPath}"])
+
+        final_command = f"{absoluteBinaryPath} {' '.join(arguments)}"
         return self.run(final_command)

--- a/src/processcdb/clangtidy.py
+++ b/src/processcdb/clangtidy.py
@@ -121,7 +121,7 @@ class ClangTidy(Tool):
 
             default_args = self.config.getlist("default_args")
             extra = f"--quiet {' '.join(default_args)}"
-            if compiler == "cl.exe":
+            if compiler.endswith("cl.exe"):
                 arguments = list(map(self.convert_arguments, arguments))
                 extra = f"{extra} --extra-arg-before=--driver-mode=cl"
 

--- a/src/processcdb/clangtidy.py
+++ b/src/processcdb/clangtidy.py
@@ -108,7 +108,6 @@ class ClangTidy(Tool):
         for compilation_unit in cdb:
             arguments = []
 
-            arguments.extend(self.config.getlist("default_args"))
             directory = Path(compilation_unit["directory"]).absolute()
             full_command = compilation_unit["arguments"]
             absolute_filename = directory / compilation_unit["file"]
@@ -120,7 +119,8 @@ class ClangTidy(Tool):
             arguments = self.convert_includes(arguments)
             arguments.extend(self.includes_as_cli_flags(self.default_includes()))
 
-            extra = "--quiet"
+            default_args = self.config.getlist("default_args")
+            extra = f"--quiet {' '.join(default_args)}"
             if compiler == "cl.exe":
                 arguments = list(map(self.convert_arguments, arguments))
                 extra = f"{extra} --extra-arg-before=--driver-mode=cl"

--- a/src/processcdb/clangtidy.py
+++ b/src/processcdb/clangtidy.py
@@ -11,9 +11,9 @@ import concurrent.futures
 from functools import partial
 import shutil
 import signal
-from .logger import LOGGER as log
-from .toolbase import Tool
-from .tidy_converter import OutputParser
+from logger import LOGGER as log
+from toolbase import Tool
+from tidy_converter import OutputParser
 
 list_of_futures = []
 

--- a/src/processcdb/clangtidy.py
+++ b/src/processcdb/clangtidy.py
@@ -127,7 +127,8 @@ class ClangTidy(Tool):
 
             if absolute_filename.is_file():
                 if self.should_scan(absolute_filename, args.file):
-                    tmp_cmd = f"cd {directory} && {self.binary} {extra} {absolute_filename} -- {' '.join(arguments)}"
+                    absoluteBinaryPath = Path(self.binary).resolve()
+                    tmp_cmd = f"cd {directory} && {absoluteBinaryPath} {extra} {absolute_filename} -- {' '.join(arguments)}"
                     command_queue.append(tmp_cmd)
                 else:
                     log.debug(f"File {absolute_filename} is not scanned")

--- a/src/processcdb/clangtidy.py
+++ b/src/processcdb/clangtidy.py
@@ -110,7 +110,7 @@ class ClangTidy(Tool):
 
             arguments.extend(self.config.getlist("default_args"))
             directory = Path(compilation_unit["directory"]).absolute()
-            full_command = compilation_unit["command"].split(" ")
+            full_command = compilation_unit["arguments"]
             absolute_filename = directory / compilation_unit["file"]
             compiler = Path(full_command[0]).name.lower()
 

--- a/src/processcdb/cppcheck.py
+++ b/src/processcdb/cppcheck.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from .toolbase import Tool
+from toolbase import Tool
 import os
 import tempfile
 import configparser

--- a/src/processcdb/cppcheck.py
+++ b/src/processcdb/cppcheck.py
@@ -80,7 +80,8 @@ class CppCheck(Tool):
                     arguments.extend(["--xml", "--xml-version=2"])
 
                 if os.path.isfile(temp_name_includes) and os.path.isfile(temp_name_sources):
-                    tmp_cmd = f"{self.binary} {' '.join(arguments)}"
+                    absoluteBinaryPath = Path(self.binary).resolve()
+                    tmp_cmd = f"{absoluteBinaryPath} {' '.join(arguments)}"
                     if args.output is not None:
                         final_command = f"{tmp_cmd} 2> {args.output}"
                     else:

--- a/src/processcdb/lizard.py
+++ b/src/processcdb/lizard.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from .toolbase import Tool
+from toolbase import Tool
 import tempfile
 import os
 

--- a/src/processcdb/misc.py
+++ b/src/processcdb/misc.py
@@ -11,11 +11,6 @@ import argparse
 from _version import get_versions
 from logger import LOGGER as log, LOG_LEVELS  # noqa: F401
 
-__author__ = "Jani Mikkonen"
-__email__ = "jani.mikkonen@gmail.com"
-__version__ = get_versions()["version"]
-
-
 def is_windows():
     return "WINDOWS" in platform.system().upper()
 
@@ -93,8 +88,7 @@ def remove_dupes(cdb):
 
 def argument_parser(tools):
     # TODO: Offload tool specific argument to the tool class itself if possible.
-    app_dirs = AppDirs("processcdb", __author__)
-    default_config_file = Path(app_dirs.user_config_dir) / "processcdb.ini"
+    default_config_file = "processcdb.ini"
     parser = argparse.ArgumentParser(description="Static analysis wrapper", epilog=f"Available tools: \n{','.join(tools.keys())}")
     parser.add_argument(
         "--cdb",

--- a/src/processcdb/misc.py
+++ b/src/processcdb/misc.py
@@ -198,6 +198,9 @@ def to_list(value):
 
 
 def to_dict(value):
+    if value == None or value == '':
+        return None
+    
     def format(val):
         k,v = val.split("=", 2)
         return {k: v.split(",")}

--- a/src/processcdb/misc.py
+++ b/src/processcdb/misc.py
@@ -8,8 +8,8 @@ from git import Repo
 from appdirs import AppDirs
 from collections import ChainMap
 import argparse
-from ._version import get_versions
-from .logger import LOGGER as log, LOG_LEVELS  # noqa: F401
+from _version import get_versions
+from logger import LOGGER as log, LOG_LEVELS  # noqa: F401
 
 __author__ = "Jani Mikkonen"
 __email__ = "jani.mikkonen@gmail.com"

--- a/src/processcdb/toolbase.py
+++ b/src/processcdb/toolbase.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from .misc import is_any_windows, capture_output, to_dict, to_list
+from misc import is_any_windows, capture_output, to_dict, to_list
 import multiprocessing
 import subprocess
 import configparser
 import os
-from .logger import LOGGER as log
+from logger import LOGGER as log
 import shutil
 import shlex
 from fnmatch import fnmatch

--- a/src/processcdb/toolbase.py
+++ b/src/processcdb/toolbase.py
@@ -157,8 +157,9 @@ class Tool(object):
     def add_additions(self, args):
         new_args = args.copy()
         additions = self.config.getdict("arg_additions")
-        for arg in args:
-            key = arg[1:]
-            if key in additions:
-                new_args.extend(additions[key])
+        if additions != None:
+            for arg in args:
+                key = arg[1:]
+                if key in additions:
+                    new_args.extend(additions[key])
         return new_args


### PR DESCRIPTION
@rasjani 
I finally managed to get some time to look into this after your comment on https://github.com/Ericsson/codechecker/issues/555. This looks to be a very useful tool so thank you for creating it, but I came across a few issues in my use case that I have fixed for me in this pull request. These I imagine are not all going to be valid in the current format to be accepted into your branch but I wanted to make you aware of the issues I came across.

- Python 3.6 has added a new error "attempted relative import with no known parent package" and it seemed to trip up your import commands. I don't know if that is because the package is not setup quite correct or I have not set my version up locally correct but making these explicit global imports instead fixed these. I assume there is a better solution for this but I don't know much about the python packaging system myself
- The compile_commands.json data it seems has two possible formats(https://clang.llvm.org/docs/JSONCompilationDatabase.html). Interestingly fastbuild(which is what my project uses to generate this) uses the "arguments" format rather than the "command" format and so I updated it to use that format. This will need to be fixed to work with both formats as this change will break yours but I expect it to not be too complicated to read the two input formats into a common format in the tool
- I had to rework a few bits as these seem to differentiate between a string[] and a dictionary so depending on how the arguments/commands change is structured these parts may be able to be reverted. I do feel sticking to a dictionary is a better structure though as the arg[2:] line in convert_includes may not find the correct data
- includes_as_system was defaulting to if none were given it would make everything a system include. I have inverted this and so nothing is a system include by default but this may be an undesirable change depending on how you see this argument used. It is an additive argument and so I felt defaulting to none made more sense
- Your details had been left in the config dumper location calculation. I ended up removing this as I was fine with it just writing into the working directory but I expect this may be better off reworking this to provide a more custom location if desired. The default I would say should be the working directory though

As I said above these changes are not in a format that can currently be accepted into your branch. If you want to take these as a starting point and refactor/improve as you need to solve the issues I came across then that would be great to hear about. If you want any testing done on my side or with different data then do ask and I can update as things change.